### PR TITLE
Initial implemntation for Runners

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod error;
+pub mod runner;
 pub use error::Error;
 
 pub mod proto {

--- a/src/runner/gptk.rs
+++ b/src/runner/gptk.rs
@@ -1,0 +1,73 @@
+use super::{Runner, RunnerInfo};
+use std::path::{Path, PathBuf};
+
+/// GPTK (Game Porting Toolkit) runner for macOS
+///
+/// GPTK is Apple's translation layer that allows running Windows games on macOS,
+/// particularly on Apple Silicon Macs. It combines Wine with Apple's D3DMetal
+/// to support DirectX 11 and 12 games.
+///
+/// # Requirements
+/// - macOS 14 Sonoma or later
+/// - Apple Silicon Mac (recommended) or Intel Mac with Rosetta 2
+/// - Command Line Tools for Xcode 15 or later
+/// - Game Porting Toolkit installed via Homebrew
+///
+/// # Example
+/// ```rust
+/// use bottles_core::runner::{GPTK, Runner};
+/// use std::path::Path;
+///
+/// // Create a GPTK runner from a path containing the gameportingtoolkit executable
+/// let gptk_path = Path::new("/opt/homebrew/bin");
+/// match GPTK::try_from(gptk_path) {
+///     Ok(gptk) => {
+///         println!("GPTK Name: {}", gptk.info().name());
+///         println!("GPTK Version: {}", gptk.info().version());
+///         println!("GPTK Available: {}", gptk.is_available());
+///     }
+///     Err(e) => println!("Failed to create GPTK runner: {}", e),
+/// }
+/// ```
+#[derive(Debug)]
+pub struct GPTK {
+    info: RunnerInfo,
+}
+
+impl TryFrom<&Path> for GPTK {
+    type Error = crate::Error;
+
+    fn try_from(path: &Path) -> Result<Self, Self::Error> {
+        let executable = PathBuf::from("./gameportingtoolkit");
+        let info = RunnerInfo::try_from(path, &executable)?;
+        Ok(GPTK { info })
+    }
+}
+
+impl Runner for GPTK {
+    fn wine(&self) -> &super::Wine {
+        todo!()
+    }
+
+    fn info(&self) -> &RunnerInfo {
+        &self.info
+    }
+
+    /// GPTK has special availability requirements - it only works on Apple Silicon Macs
+    /// running macOS 14 Sonoma or later with Rosetta 2
+    fn is_available(&self) -> bool {
+        if !self.info().executable_path().exists() {
+            return false;
+        }
+
+        // Check if running under Rosetta or on Apple Silicon
+        use std::process::Command;
+        let arch_output = Command::new("arch")
+            .output()
+            .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+            .unwrap_or_default();
+
+        // GPTK requires either x86_64 (Rosetta) or arm64 (Apple Silicon)
+        arch_output == "i386" || arch_output == "arm64"
+    }
+}

--- a/src/runner/gptk.rs
+++ b/src/runner/gptk.rs
@@ -5,7 +5,15 @@ use std::path::{Path, PathBuf};
 ///
 /// GPTK is Apple's translation layer that allows running Windows games on macOS,
 /// particularly on Apple Silicon Macs. It combines Wine with Apple's D3DMetal
-/// to support DirectX 11 and 12 games.
+/// to support DirectX 11 and 12 games with hardware acceleration.
+///
+/// # Features
+///
+/// - DirectX 11 and 12 support through D3DMetal translation
+/// - Optimized for Apple Silicon architecture
+/// - Integration with macOS graphics stack
+/// - Metal Performance Shaders acceleration
+/// - Enhanced gaming compatibility on macOS
 ///
 /// # Requirements
 /// - macOS 14 Sonoma or later

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -207,4 +207,12 @@ pub trait Runner {
         let executable_path = self.info().executable_path();
         executable_path.exists() && executable_path.is_file()
     }
+
+    /// Initialize a prefix at the specified path using the runner's executable.
+    ///
+    /// # Arguments
+    ///
+    /// * `prefix` - Path where the new prefix should be created. The directory will be
+    ///   created if it doesn't exist.
+    fn initialize(&self, prefix: impl AsRef<Path>) -> Result<(), Error>;
 }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -96,6 +96,11 @@ impl RunnerInfo {
 }
 
 pub trait Runner {
+    /// Get the Wine runner associated with this runner
+    ///
+    /// This is possible because all runners are built on top of Wine
+    fn wine(&self) -> &Wine;
+
     /// Get the common runner information
     fn info(&self) -> &RunnerInfo;
 

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -108,6 +108,9 @@ pub trait Runner {
     /// Get the common runner information
     fn info(&self) -> &RunnerInfo;
 
+    /// Get the common runner information
+    fn info_mut(&mut self) -> &mut RunnerInfo;
+
     /// Check if the runner executable is available and functional
     fn is_available(&self) -> bool {
         let executable_path = self.info().executable_path();

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -16,17 +16,39 @@ use std::{
     process::Command,
 };
 
-/// Common information about a runner
+/// Contains metadata and paths for any runner implementation. This struct is used
+/// internally by all runner types to store their basic information.
 #[derive(Debug)]
 pub struct RunnerInfo {
+    /// Human-readable name of the runner, typically derived from the directory name
     name: String,
+    /// Version string obtained from the runner's `--version` output
     version: String,
+    /// Base directory where the runner is installed
     directory: PathBuf,
+    /// Relative path to the main executable within the directory
     executable: PathBuf,
 }
 
 impl RunnerInfo {
-    // This fuction is only meant to be called by the runners themselves hence this is not public
+    /// Create a new RunnerInfo by validating the directory and executable
+    ///
+    /// This function is only meant to be called by the runners themselves, hence it's not public.
+    /// It performs validation to ensure the directory exists and contains the specified executable.
+    ///
+    /// # Arguments
+    ///
+    /// * `directory` - The base directory where the runner is installed
+    /// * `executable` - The relative path to the executable within the directory
+    ///
+    /// # Returns
+    ///
+    /// Returns a `RunnerInfo` instance if validation succeeds
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the directory or executable path is invalid,
+    /// or if the executable cannot be executed to determine its version.
     fn try_from(directory: &Path, executable: &Path) -> Result<Self, Error> {
         if !directory.exists() {
             return Err(std::io::Error::new(
@@ -77,41 +99,110 @@ impl RunnerInfo {
     }
 
     /// Get the full path to the executable for the runner
+    ///
+    /// Combines the base directory with the relative executable path to provide
+    /// the complete path that can be used to execute the runner.
+    ///
+    /// # Returns
+    ///
+    /// A `PathBuf` containing the full path to the runner's executable
     pub fn executable_path(&self) -> PathBuf {
         self.directory.join(&self.executable)
     }
 }
 
 impl RunnerInfo {
-    /// Name of the runner
+    /// Get the name of the runner
+    ///
+    /// Returns the human-readable name, typically derived from the directory name
+    /// where the runner is installed.
+    ///
+    /// # Returns
+    ///
+    /// A string slice containing the runner's name
     pub fn name(&self) -> &str {
         &self.name
     }
 
-    /// Version of the runner
+    /// Get the version of the runner
+    ///
+    /// Returns the version string as reported by the runner's `--version` command.
+    /// If the version cannot be determined, this may return the runner's name instead.
+    ///
+    /// # Returns
+    ///
+    /// A string slice containing the runner's version information
     pub fn version(&self) -> &str {
         &self.version
     }
 
-    /// Directory where the runner is located
+    /// Returns the directory path where the runner is installed.
+    ///
+    /// # Returns
+    ///
+    /// A path reference to the runner's installation directory
     pub fn directory(&self) -> &Path {
         &self.directory
     }
 }
 
+/// Trait defining the common interface for all Windows compatibility runners
+///
+/// All runners in this module implement this trait, providing a unified way to interact
+/// with different compatibility layers like Wine, Proton, UMU, and GPTK.
 pub trait Runner {
     /// Get the Wine runner associated with this runner
     ///
-    /// This is possible because all runners are built on top of Wine
+    /// All runners are built on top of Wine, so this method provides access to the
+    /// underlying Wine instance. This allows for Wine-specific operations and
+    /// configuration even when using higher-level runners like Proton.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the underlying Wine runner instance
     fn wine(&self) -> &Wine;
 
-    /// Get the common runner information
+    /// Provides access to metadata about the runner including its name, version,
+    /// installation directory, and executable path.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the runner's information structure
     fn info(&self) -> &RunnerInfo;
 
-    /// Get the common runner information
+    /// Get a mutable reference to the common runner information
+    ///
+    /// Allows modification of the runner's metadata. This is typically used
+    /// internally by runner implementations during initialization.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to the runner's information structure
     fn info_mut(&mut self) -> &mut RunnerInfo;
 
-    /// Check if the runner executable is available and functional
+    /// Performs basic validation to ensure the runner can be executed. The default
+    /// implementation checks if the executable file exists and is accessible.
+    /// Individual runners may override this to perform additional checks.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the runner appears to be functional, `false` otherwise
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bottles_core::runner::{Wine, Runner};
+    /// use std::path::Path;
+    ///
+    /// let wine_path = Path::new("/usr/bin/wine");
+    /// if let Ok(wine) = Wine::try_from(wine_path) {
+    ///     if wine.is_available() {
+    ///         println!("Wine is ready to use");
+    ///     } else {
+    ///         println!("Wine is not available");
+    ///     }
+    /// }
+    /// ```
     fn is_available(&self) -> bool {
         let executable_path = self.info().executable_path();
         executable_path.exists() && executable_path.is_file()

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -22,24 +22,26 @@ pub struct RunnerInfo {
 
 impl RunnerInfo {
     // This fuction is only meant to be called by the runners themselves hence this is not public
-    fn try_from(directory: &Path, executable: &Path) -> Result<Self, Box<dyn std::error::Error>> {
+    fn try_from(directory: &Path, executable: &Path) -> Result<Self, Error> {
         if !directory.exists() {
-            return Err(Box::new(std::io::Error::new(
+            return Err(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 format!("'{}' does not exist", directory.display()),
-            )));
+            )
+            .into());
         }
         let full_path = directory.join(executable);
 
         if !full_path.exists() || !full_path.is_file() {
-            return Err(Box::new(Error::Io(std::io::Error::new(
+            return Err(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 format!(
                     "Executable '{}' not found in directory '{}'",
                     executable.display(),
                     directory.display()
                 ),
-            ))));
+            )
+            .into());
         }
 
         let name = directory
@@ -59,7 +61,7 @@ impl RunnerInfo {
                     ver
                 }
             })
-            .map_err(|e| Error::Io(e))?;
+            .map_err(Error::Io)?;
 
         Ok(RunnerInfo {
             name,

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -18,6 +18,7 @@ pub struct RunnerInfo {
     name: String,
     version: String,
     directory: PathBuf,
+    executable: PathBuf,
 }
 
 impl RunnerInfo {
@@ -66,8 +67,14 @@ impl RunnerInfo {
         Ok(RunnerInfo {
             name,
             directory: directory.to_path_buf(),
+            executable: executable.to_path_buf(),
             version,
         })
+    }
+
+    /// Get the full path to the executable for the runner
+    pub fn executable_path(&self) -> PathBuf {
+        self.directory.join(&self.executable)
     }
 }
 
@@ -89,13 +96,12 @@ impl RunnerInfo {
 }
 
 pub trait Runner {
-    const EXECUTABLE: &'static str;
     /// Get the common runner information
     fn info(&self) -> &RunnerInfo;
 
     /// Check if the runner executable is available and functional
     fn is_available(&self) -> bool {
-        let executable_path = self.info().directory().join(Self::EXECUTABLE);
+        let executable_path = self.info().executable_path();
         executable_path.exists() && executable_path.is_file()
     }
 }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1,7 +1,11 @@
+#[cfg(target_os = "macos")]
+mod gptk;
 mod proton;
 mod umu;
 mod wine;
 
+#[cfg(target_os = "macos")]
+pub use gptk::GPTK;
 pub use proton::Proton;
 pub use umu::UMU;
 pub use wine::Wine;

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1,0 +1,99 @@
+mod proton;
+mod umu;
+mod wine;
+
+pub use proton::Proton;
+pub use umu::UMU;
+pub use wine::Wine;
+
+use crate::Error;
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+/// Common information about a runner
+#[derive(Debug)]
+pub struct RunnerInfo {
+    name: String,
+    version: String,
+    directory: PathBuf,
+}
+
+impl RunnerInfo {
+    // This fuction is only meant to be called by the runners themselves hence this is not public
+    fn try_from(directory: &Path, executable: &Path) -> Result<Self, Box<dyn std::error::Error>> {
+        if !directory.exists() {
+            return Err(Box::new(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("'{}' does not exist", directory.display()),
+            )));
+        }
+        let full_path = directory.join(executable);
+
+        if !full_path.exists() || !full_path.is_file() {
+            return Err(Box::new(Error::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!(
+                    "Executable '{}' not found in directory '{}'",
+                    executable.display(),
+                    directory.display()
+                ),
+            ))));
+        }
+
+        let name = directory
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+
+        let version = Command::new(&full_path)
+            .arg("--version")
+            .output()
+            .map(|output| {
+                let ver = String::from_utf8_lossy(&output.stdout).to_string();
+                if ver.is_empty() {
+                    name.clone()
+                } else {
+                    ver
+                }
+            })
+            .map_err(|e| Error::Io(e))?;
+
+        Ok(RunnerInfo {
+            name,
+            directory: directory.to_path_buf(),
+            version,
+        })
+    }
+}
+
+impl RunnerInfo {
+    /// Name of the runner
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Version of the runner
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    /// Directory where the runner is located
+    pub fn directory(&self) -> &Path {
+        &self.directory
+    }
+}
+
+pub trait Runner {
+    const EXECUTABLE: &'static str;
+    /// Get the common runner information
+    fn info(&self) -> &RunnerInfo;
+
+    /// Check if the runner executable is available and functional
+    fn is_available(&self) -> bool {
+        let executable_path = self.info().directory().join(Self::EXECUTABLE);
+        executable_path.exists() && executable_path.is_file()
+    }
+}

--- a/src/runner/proton.rs
+++ b/src/runner/proton.rs
@@ -1,9 +1,16 @@
 use super::{Runner, RunnerInfo, Wine};
 use std::path::{Path, PathBuf};
 
-// TODO: These need to be set to use proton outside steam
-// STEAM_COMPAT_DATA_PATH
-// STEAM_COMPAT_CLIENT_INSTALL_PATH
+/// Proton runner implementation
+///
+/// Proton is Valve's Wine fork designed specifically for gaming on Linux. It includes
+/// numerous patches and enhancements over standard Wine, making it particularly
+/// effective for running Windows games through Steam or standalone.
+///
+/// # Note
+/// When used outside of Steam, Proton requires specific environment variables:
+/// - `STEAM_COMPAT_DATA_PATH`: Path to store compatibility data
+/// - `STEAM_COMPAT_CLIENT_INSTALL_PATH`: Steam installation directory
 #[derive(Debug)]
 pub struct Proton {
     info: RunnerInfo,

--- a/src/runner/proton.rs
+++ b/src/runner/proton.rs
@@ -13,14 +13,13 @@ impl TryFrom<&Path> for Proton {
     type Error = Box<dyn std::error::Error>;
 
     fn try_from(path: &Path) -> Result<Self, Self::Error> {
-        let executable = PathBuf::from(Self::EXECUTABLE);
+        let executable = PathBuf::from("./proton");
         let info = RunnerInfo::try_from(path, &executable)?;
         Ok(Proton { info })
     }
 }
 
 impl Runner for Proton {
-    const EXECUTABLE: &'static str = "proton";
     fn info(&self) -> &RunnerInfo {
         &self.info
     }

--- a/src/runner/proton.rs
+++ b/src/runner/proton.rs
@@ -1,4 +1,4 @@
-use super::{Runner, RunnerInfo};
+use super::{Runner, RunnerInfo, Wine};
 use std::path::{Path, PathBuf};
 
 // TODO: These need to be set to use proton outside steam
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 #[derive(Debug)]
 pub struct Proton {
     info: RunnerInfo,
+    wine: Wine,
 }
 
 impl TryFrom<&Path> for Proton {
@@ -15,11 +16,16 @@ impl TryFrom<&Path> for Proton {
     fn try_from(path: &Path) -> Result<Self, Self::Error> {
         let executable = PathBuf::from("./proton");
         let info = RunnerInfo::try_from(path, &executable)?;
-        Ok(Proton { info })
+        let mut wine = Wine::try_from(path.join("files").as_path())?;
+        Ok(Proton { wine, info })
     }
 }
 
 impl Runner for Proton {
+    fn wine(&self) -> &Wine {
+        &self.wine
+    }
+
     fn info(&self) -> &RunnerInfo {
         &self.info
     }

--- a/src/runner/proton.rs
+++ b/src/runner/proton.rs
@@ -1,0 +1,27 @@
+use super::{Runner, RunnerInfo};
+use std::path::{Path, PathBuf};
+
+// TODO: These need to be set to use proton outside steam
+// STEAM_COMPAT_DATA_PATH
+// STEAM_COMPAT_CLIENT_INSTALL_PATH
+#[derive(Debug)]
+pub struct Proton {
+    info: RunnerInfo,
+}
+
+impl TryFrom<&Path> for Proton {
+    type Error = Box<dyn std::error::Error>;
+
+    fn try_from(path: &Path) -> Result<Self, Self::Error> {
+        let executable = PathBuf::from(Self::EXECUTABLE);
+        let info = RunnerInfo::try_from(path, &executable)?;
+        Ok(Proton { info })
+    }
+}
+
+impl Runner for Proton {
+    const EXECUTABLE: &'static str = "proton";
+    fn info(&self) -> &RunnerInfo {
+        &self.info
+    }
+}

--- a/src/runner/proton.rs
+++ b/src/runner/proton.rs
@@ -1,5 +1,8 @@
 use super::{Runner, RunnerInfo, Wine};
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 /// Proton runner implementation
 ///
@@ -40,5 +43,17 @@ impl Runner for Proton {
 
     fn info_mut(&mut self) -> &mut RunnerInfo {
         &mut self.info
+    }
+
+    fn initialize(&self, prefix: impl AsRef<Path>) -> Result<(), crate::Error> {
+        Command::new(self.info().executable_path())
+            .arg("run")
+            .arg("wineboot")
+            .env("WINEPREFIX", prefix.as_ref())
+            .env("STEAM_COMPAT_DATA_PATH", prefix.as_ref())
+            .env("STEAM_COMPAT_CLIENT_INSTALL_PATH", "")
+            .output()?;
+
+        Ok(())
     }
 }

--- a/src/runner/proton.rs
+++ b/src/runner/proton.rs
@@ -17,6 +17,7 @@ impl TryFrom<&Path> for Proton {
         let executable = PathBuf::from("./proton");
         let info = RunnerInfo::try_from(path, &executable)?;
         let mut wine = Wine::try_from(path.join("files").as_path())?;
+        wine.info_mut().name = info.name.clone();
         Ok(Proton { wine, info })
     }
 }
@@ -28,5 +29,9 @@ impl Runner for Proton {
 
     fn info(&self) -> &RunnerInfo {
         &self.info
+    }
+
+    fn info_mut(&mut self) -> &mut RunnerInfo {
+        &mut self.info
     }
 }

--- a/src/runner/proton.rs
+++ b/src/runner/proton.rs
@@ -46,6 +46,7 @@ impl Runner for Proton {
     }
 
     fn initialize(&self, prefix: impl AsRef<Path>) -> Result<(), crate::Error> {
+        // FIXME: Launch winebridge to initialize the prefix
         Command::new(self.info().executable_path())
             .arg("run")
             .arg("wineboot")

--- a/src/runner/umu.rs
+++ b/src/runner/umu.rs
@@ -1,0 +1,35 @@
+use super::{Runner, RunnerInfo};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub struct UMU {
+    info: RunnerInfo,
+    proton_path: Option<PathBuf>,
+}
+
+impl TryFrom<&Path> for UMU {
+    type Error = Box<dyn std::error::Error>;
+
+    fn try_from(path: &Path) -> Result<Self, Self::Error> {
+        let executable = PathBuf::from(Self::EXECUTABLE);
+        let mut info = RunnerInfo::try_from(path, &executable)?;
+        let pretty_version = info
+            .version
+            .split_whitespace()
+            .nth(2)
+            .unwrap_or("unknown")
+            .to_string();
+        info.version = pretty_version;
+        Ok(UMU {
+            info,
+            proton_path: None,
+        })
+    }
+}
+
+impl Runner for UMU {
+    const EXECUTABLE: &'static str = "umu-run";
+    fn info(&self) -> &RunnerInfo {
+        &self.info
+    }
+}

--- a/src/runner/umu.rs
+++ b/src/runner/umu.rs
@@ -11,7 +11,7 @@ impl TryFrom<&Path> for UMU {
     type Error = Box<dyn std::error::Error>;
 
     fn try_from(path: &Path) -> Result<Self, Self::Error> {
-        let executable = PathBuf::from(Self::EXECUTABLE);
+        let executable = PathBuf::from("./umu-run");
         let mut info = RunnerInfo::try_from(path, &executable)?;
         let pretty_version = info
             .version
@@ -28,7 +28,6 @@ impl TryFrom<&Path> for UMU {
 }
 
 impl Runner for UMU {
-    const EXECUTABLE: &'static str = "umu-run";
     fn info(&self) -> &RunnerInfo {
         &self.info
     }

--- a/src/runner/umu.rs
+++ b/src/runner/umu.rs
@@ -1,9 +1,19 @@
 use super::{Proton, Runner, RunnerInfo, Wine};
 use std::path::{Path, PathBuf};
 
+/// UMU (Unified Launcher) runner implementation
+///
+/// UMU is a universal compatibility layer that wraps other runners like Proton
+/// to provide enhanced game compatibility and launcher functionality. It can
+/// automatically configure optimal settings for different games and provides
+/// a unified interface for various Windows compatibility tools.
 #[derive(Debug)]
 pub struct UMU {
     info: RunnerInfo,
+    /// Underlying Proton runner that UMU wraps
+    ///
+    /// When present, UMU will use this Proton instance to run applications.
+    /// If None, UMU will download the latest Proton version it can find and set that up.
     proton: Option<Proton>,
 }
 

--- a/src/runner/umu.rs
+++ b/src/runner/umu.rs
@@ -1,5 +1,8 @@
 use super::{Proton, Runner, RunnerInfo, Wine};
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 /// UMU (Unified Launcher) runner implementation
 ///
@@ -47,5 +50,15 @@ impl Runner for UMU {
 
     fn info_mut(&mut self) -> &mut RunnerInfo {
         &mut self.info
+    }
+
+    fn initialize(&self, prefix: impl AsRef<Path>) -> Result<(), crate::Error> {
+        let proton_path = self.proton.as_ref().unwrap().info().directory();
+        Command::new(self.info().executable_path())
+            .arg("wineboot") // This is wrong but it'll anyways initialize the prefix
+            .env("WINEPREFIX", prefix.as_ref())
+            .env("PROTONPATH", proton_path)
+            .output()?;
+        Ok(())
     }
 }

--- a/src/runner/umu.rs
+++ b/src/runner/umu.rs
@@ -53,6 +53,7 @@ impl Runner for UMU {
     }
 
     fn initialize(&self, prefix: impl AsRef<Path>) -> Result<(), crate::Error> {
+        // FIXME: Launch winebridge to initialize the prefix
         let proton_path = self.proton.as_ref().unwrap().info().directory();
         Command::new(self.info().executable_path())
             .arg("wineboot") // This is wrong but it'll anyways initialize the prefix

--- a/src/runner/umu.rs
+++ b/src/runner/umu.rs
@@ -1,16 +1,17 @@
-use super::{Runner, RunnerInfo};
+use super::{Proton, Runner, RunnerInfo, Wine};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
 pub struct UMU {
     info: RunnerInfo,
-    proton_path: Option<PathBuf>,
+    proton: Option<Proton>,
 }
 
-impl TryFrom<&Path> for UMU {
-    type Error = Box<dyn std::error::Error>;
-
-    fn try_from(path: &Path) -> Result<Self, Self::Error> {
+impl UMU {
+    pub fn try_from(
+        path: &Path,
+        proton: Option<Proton>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         let executable = PathBuf::from("./umu-run");
         let mut info = RunnerInfo::try_from(path, &executable)?;
         let pretty_version = info
@@ -20,14 +21,16 @@ impl TryFrom<&Path> for UMU {
             .unwrap_or("unknown")
             .to_string();
         info.version = pretty_version;
-        Ok(UMU {
-            info,
-            proton_path: None,
-        })
+        Ok(UMU { info, proton })
     }
 }
 
 impl Runner for UMU {
+    fn wine(&self) -> &Wine {
+        // TODO: Make sure an unwrap is possible
+        self.proton.as_ref().unwrap().wine()
+    }
+
     fn info(&self) -> &RunnerInfo {
         &self.info
     }

--- a/src/runner/umu.rs
+++ b/src/runner/umu.rs
@@ -34,4 +34,8 @@ impl Runner for UMU {
     fn info(&self) -> &RunnerInfo {
         &self.info
     }
+
+    fn info_mut(&mut self) -> &mut RunnerInfo {
+        &mut self.info
+    }
 }

--- a/src/runner/wine.rs
+++ b/src/runner/wine.rs
@@ -21,14 +21,13 @@ impl TryFrom<&Path> for Wine {
     type Error = Box<dyn std::error::Error>;
 
     fn try_from(path: &Path) -> Result<Self, Self::Error> {
-        let executable = PathBuf::from(Self::EXECUTABLE);
+        let executable = PathBuf::from("./bin/wine");
         let info = RunnerInfo::try_from(path, &executable)?;
         Ok(Wine { info })
     }
 }
 
 impl Runner for Wine {
-    const EXECUTABLE: &'static str = "bin/wine";
     fn info(&self) -> &RunnerInfo {
         &self.info
     }

--- a/src/runner/wine.rs
+++ b/src/runner/wine.rs
@@ -1,0 +1,35 @@
+use super::{Runner, RunnerInfo};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub struct Wine {
+    info: RunnerInfo,
+}
+
+pub enum PrefixArch {
+    Win32,
+    Win64,
+}
+
+pub enum WindowsVersion {
+    Win7,
+    Win8,
+    Win10,
+}
+
+impl TryFrom<&Path> for Wine {
+    type Error = Box<dyn std::error::Error>;
+
+    fn try_from(path: &Path) -> Result<Self, Self::Error> {
+        let executable = PathBuf::from(Self::EXECUTABLE);
+        let info = RunnerInfo::try_from(path, &executable)?;
+        Ok(Wine { info })
+    }
+}
+
+impl Runner for Wine {
+    const EXECUTABLE: &'static str = "bin/wine";
+    fn info(&self) -> &RunnerInfo {
+        &self.info
+    }
+}

--- a/src/runner/wine.rs
+++ b/src/runner/wine.rs
@@ -28,6 +28,10 @@ impl TryFrom<&Path> for Wine {
 }
 
 impl Runner for Wine {
+    fn wine(&self) -> &Wine {
+        self
+    }
+
     fn info(&self) -> &RunnerInfo {
         &self.info
     }

--- a/src/runner/wine.rs
+++ b/src/runner/wine.rs
@@ -35,4 +35,8 @@ impl Runner for Wine {
     fn info(&self) -> &RunnerInfo {
         &self.info
     }
+
+    fn info_mut(&mut self) -> &mut RunnerInfo {
+        &mut self.info
+    }
 }

--- a/src/runner/wine.rs
+++ b/src/runner/wine.rs
@@ -1,16 +1,35 @@
 use super::{Runner, RunnerInfo};
 use std::path::{Path, PathBuf};
 
+/// Wine runner implementation
+///
+/// Wine is the base compatibility layer that all other runners build upon. It provides
+/// the core Windows API translation functionality that allows Windows applications
+/// to run on Unix-like systems.
 #[derive(Debug)]
 pub struct Wine {
     info: RunnerInfo,
 }
 
+/// Architecture for Wine prefix creation
+///
+/// Determines whether a Wine prefix should be configured for 32-bit or 64-bit
+/// Windows compatibility. This affects which Windows applications can run
+/// in the prefix
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PrefixArch {
+    /// 32-bit Windows prefix architecture
     Win32,
+    /// 64-bit Windows prefix architecture (recommended)
     Win64,
 }
 
+/// Windows version compatibility settings
+///
+/// Specifies which version of Windows the Wine prefix should emulate.
+/// Different applications may require specific Windows versions for
+/// optimal compatibility.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WindowsVersion {
     Win7,
     Win8,

--- a/src/runner/wine.rs
+++ b/src/runner/wine.rs
@@ -61,6 +61,7 @@ impl Runner for Wine {
     }
 
     fn initialize(&self, prefix: impl AsRef<Path>) -> Result<(), crate::Error> {
+        // FIXME: Launch winebridge to initialize the prefix
         Command::new(self.info().executable_path())
             .arg("wineboot")
             .arg("--init")

--- a/src/runner/wine.rs
+++ b/src/runner/wine.rs
@@ -1,5 +1,6 @@
 use super::{Runner, RunnerInfo};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 /// Wine runner implementation
 ///
@@ -57,5 +58,15 @@ impl Runner for Wine {
 
     fn info_mut(&mut self) -> &mut RunnerInfo {
         &mut self.info
+    }
+
+    fn initialize(&self, prefix: impl AsRef<Path>) -> Result<(), crate::Error> {
+        Command::new(self.info().executable_path())
+            .arg("wineboot")
+            .arg("--init")
+            .env("WINEPREFIX", prefix.as_ref())
+            .output()?;
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Each runner has been put into it's own source file because eventually for each runner we will define the options they support as enums in the same files.