### PR TITLE
feat: virgo client for fvs2d

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ derive_builder.workspace = true
 url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["serde"] }
 prost = "0.14"
+prost-types = "0.14"
 tonic-prost = "0.14"
 
 [build-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -3,9 +3,14 @@ use std::error::Error;
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=proto/bottles.proto");
     println!("cargo:rerun-if-changed=proto/winebridge.proto");
+    println!("cargo:rerun-if-changed=proto/fvs2d.proto");
 
     tonic_prost_build::configure().compile_protos(
-        &["proto/bottles.proto", "proto/winebridge.proto"],
+        &[
+            "proto/bottles.proto",
+            "proto/winebridge.proto",
+            "proto/fvs2d.proto",
+        ],
         &["proto/"],
     )?;
     Ok(())

--- a/examples/layers_demo.rs
+++ b/examples/layers_demo.rs
@@ -34,7 +34,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     mgr.capture(&dep, &virgo, "dep")?;
     let dep_patch = dep.join(".fvs2/registry/system.reg.patch");
     println!("captured dep layer files : {:?}", list(&dep));
-    println!("captured registry patch  : {} ops", dep_patch.exists().then(|| count_ops(&dep_patch)).unwrap_or(0));
+    println!(
+        "captured registry patch  : {} ops",
+        dep_patch
+            .exists()
+            .then(|| count_ops(&dep_patch))
+            .unwrap_or(0)
+    );
 
     // --- REPLAY: mount virgo + dep over a fresh upper (patches auto-discovered) ---
     let upper2 = work.join("upper2");
@@ -45,13 +51,31 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
     let merged = fs::read_to_string(mount.path().join("system.reg"))?;
     println!("replay NewDep present    : {}", merged.contains("NewDep"));
-    println!("replay ToUpdate Ver2.0   : {}", merged.contains("\"Ver\"=\"2.0\""));
-    println!("replay ToDelete gone     : {}", !merged.contains("ToDelete"));
-    println!("replay newdep.dll        : {:?}", fs::read_to_string(mount.path().join("system32/newdep.dll"))?);
-    println!("replay core.dll (virgo)  : {:?}", fs::read_to_string(mount.path().join("system32/core.dll"))?);
-    println!("merged in upper2         : {}", upper2.join("system.reg").exists());
+    println!(
+        "replay ToUpdate Ver2.0   : {}",
+        merged.contains("\"Ver\"=\"2.0\"")
+    );
+    println!(
+        "replay ToDelete gone     : {}",
+        !merged.contains("ToDelete")
+    );
+    println!(
+        "replay newdep.dll        : {:?}",
+        fs::read_to_string(mount.path().join("system32/newdep.dll"))?
+    );
+    println!(
+        "replay core.dll (virgo)  : {:?}",
+        fs::read_to_string(mount.path().join("system32/core.dll"))?
+    );
+    println!(
+        "merged in upper2         : {}",
+        upper2.join("system.reg").exists()
+    );
     let base = fs::read_to_string(virgo.join("system.reg"))?;
-    println!("virgo untouched          : {}", base.contains("\"Ver\"=\"1.0\"") && base.contains("ToDelete"));
+    println!(
+        "virgo untouched          : {}",
+        base.contains("\"Ver\"=\"1.0\"") && base.contains("ToDelete")
+    );
 
     drop(mount);
     println!("OK");

--- a/proto/fvs2d.proto
+++ b/proto/fvs2d.proto
@@ -1,0 +1,145 @@
+syntax = "proto3";
+
+package fvs2d.v1;
+
+option go_package = "fvs2d/internal/fvs2dpb;fvs2dpb";
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
+service Fvs2d {
+    rpc Probe(google.protobuf.Empty) returns (ProbeResponse);
+    rpc InitRepository(InitRepositoryRequest) returns (Repository);
+    rpc Commit(CommitRequest) returns (Revision);
+    rpc ListStates(ListStatesRequest) returns (ListStatesResponse);
+    rpc Restore(RestoreRequest) returns (RestoreResponse);
+    rpc CreateMount(CreateMountRequest) returns (Mount);
+    rpc GetMount(GetMountRequest) returns (Mount);
+    rpc ListMounts(google.protobuf.Empty) returns (ListMountsResponse);
+    rpc Unmount(UnmountRequest) returns (google.protobuf.Empty);
+    rpc Shutdown(ShutdownRequest) returns (google.protobuf.Empty);
+}
+
+message ListStatesRequest {
+    string repository_path = 1;
+}
+
+message State {
+    string state_id = 1;
+    google.protobuf.Timestamp created_at = 2;
+    string message = 3;
+}
+
+message ListStatesResponse {
+    repeated State states = 1;
+}
+
+message RestoreRequest {
+    string repository_path = 1;
+    string state_id_or_prefix = 2;
+    // destination_path overrides the restore destination (default: the repo root).
+    optional string destination_path = 3;
+    // clean removes files in the destination that are not part of the state.
+    bool clean = 4;
+    // reset moves HEAD to the restored state.
+    bool reset = 5;
+}
+
+message RestoreResponse {
+    string state_id = 1;
+    string destination_path = 2;
+}
+
+message InitRepositoryRequest {
+    string repository_path = 1;
+    uint32 block_size = 2;
+}
+
+message Repository {
+    string repository_path = 1;
+    uint32 block_size = 2;
+}
+
+message CommitRequest {
+    string repository_path = 1;
+    string message = 2;
+    bool allow_empty = 3;
+}
+
+message Revision {
+    string repository_path = 1;
+    string state_id = 2;
+    google.protobuf.Timestamp created_at = 3;
+    uint64 file_count = 4;
+}
+
+message ProbeResponse {
+    string daemon_version = 1;
+    uint32 pid = 2;
+    google.protobuf.Timestamp started_at = 3;
+
+    bool fuse_backend_available = 4;
+    bool dev_fuse_accessible = 5;
+    bool fusermount_available = 6;
+    bool running_in_flatpak = 7;
+}
+
+message RevisionSelector {
+    oneof selector {
+        string state_id_or_prefix = 1;
+        string branch = 2;
+    }
+}
+
+message Layer {
+    string repository_path = 1;
+    RevisionSelector revision = 2;
+}
+
+message MountSpec {
+    string mount_point = 1;
+    repeated Layer layers = 2;
+    optional string upper_path = 3;
+    bool debug = 4;
+}
+
+message CreateMountRequest {
+    MountSpec spec = 1;
+}
+
+message ResolvedLayer {
+    string repository_path = 1;
+    string state_id = 2;
+    string blocks_path = 3;
+    uint32 block_size = 4;
+}
+
+message Mount {
+    string id = 1;
+    MountSpec spec = 2;
+    repeated ResolvedLayer resolved_layers = 3;
+    uint64 node_count = 4;
+    google.protobuf.Timestamp mounted_at = 5;
+}
+
+message GetMountRequest {
+    string mount_id = 1;
+}
+
+message ListMountsResponse {
+    repeated Mount mounts = 1;
+}
+
+enum UnmountMode {
+    UNMOUNT_MODE_NORMAL = 0;
+    UNMOUNT_MODE_LAZY = 1;
+}
+
+message UnmountRequest {
+    string mount_id = 1;
+    UnmountMode mode = 2;
+}
+
+message ShutdownRequest {
+    UnmountMode mode = 1;
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::{layers::LayersError, runner::RunnerError, winebridge::BridgeError};
+use crate::{layers::LayersError, runner::RunnerError, virgo::VirgoError, winebridge::BridgeError};
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Error, Debug)]
@@ -19,6 +19,8 @@ pub enum Error {
     Bridge(#[from] BridgeError),
     #[error("Runner error: {0}")]
     Runner(#[from] RunnerError),
+    #[error("Virgo error: {0}")]
+    Virgo(#[from] VirgoError),
 }
 
 #[allow(dead_code)]

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -52,7 +52,9 @@ impl Tools {
     /// to the bare names resolved through `PATH`.
     pub fn from_env() -> Self {
         let pick = |var: &str, default: &str| {
-            std::env::var_os(var).map(PathBuf::from).unwrap_or_else(|| PathBuf::from(default))
+            std::env::var_os(var)
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from(default))
         };
         Self {
             fvs2d: pick("FVS2D_BIN", "fvs2d"),
@@ -71,11 +73,17 @@ pub struct LayerRef {
 
 impl LayerRef {
     pub fn head(repo: impl Into<PathBuf>) -> Self {
-        Self { repo: repo.into(), state: None }
+        Self {
+            repo: repo.into(),
+            state: None,
+        }
     }
 
     pub fn state(repo: impl Into<PathBuf>, state: impl Into<String>) -> Self {
-        Self { repo: repo.into(), state: Some(state.into()) }
+        Self {
+            repo: repo.into(),
+            state: Some(state.into()),
+        }
     }
 
     fn to_arg(&self) -> String {
@@ -98,7 +106,10 @@ impl Mount {
     }
 
     pub fn unmount(&mut self) {
-        let _ = Command::new("fusermount3").arg("-u").arg(&self.mountpoint).status();
+        let _ = Command::new("fusermount3")
+            .arg("-u")
+            .arg(&self.mountpoint)
+            .status();
         if let Some(mut child) = self.child.take() {
             let _ = child.wait();
         }
@@ -131,7 +142,12 @@ impl LayerManager {
 
     /// Mounts a stack of layers (low to high) at `mountpoint`, optionally backed
     /// by a writable `upper`. Returns once the mount is visible.
-    pub fn mount(&self, lowers: &[LayerRef], upper: Option<&Path>, mountpoint: &Path) -> Result<Mount> {
+    pub fn mount(
+        &self,
+        lowers: &[LayerRef],
+        upper: Option<&Path>,
+        mountpoint: &Path,
+    ) -> Result<Mount> {
         std::fs::create_dir_all(mountpoint)?;
         let mut cmd = Command::new(&self.tools.fvs2d);
         cmd.arg("-mount").arg(mountpoint);
@@ -142,8 +158,14 @@ impl LayerManager {
             std::fs::create_dir_all(u)?;
             cmd.arg("-upper").arg(u);
         }
-        let child = cmd.spawn().map_err(|e| LayersError::Spawn { tool: "fvs2d".into(), source: e })?;
-        let mount = Mount { child: Some(child), mountpoint: mountpoint.to_path_buf() };
+        let child = cmd.spawn().map_err(|e| LayersError::Spawn {
+            tool: "fvs2d".into(),
+            source: e,
+        })?;
+        let mount = Mount {
+            child: Some(child),
+            mountpoint: mountpoint.to_path_buf(),
+        };
         wait_mounted(mountpoint)?;
         Ok(mount)
     }
@@ -184,7 +206,12 @@ impl LayerManager {
     /// the directory's `.fvs2` repo at its new HEAD).
     pub fn commit_layer(&self, dir: &Path, message: &str) -> Result<()> {
         let _ = self.run(&self.tools.fvs2, Some(dir), ["init"], "fvs2");
-        self.run(&self.tools.fvs2, Some(dir), ["commit", "-m", message], "fvs2")
+        self.run(
+            &self.tools.fvs2,
+            Some(dir),
+            ["commit", "-m", message],
+            "fvs2",
+        )
     }
 
     /// Mounts the stack over a writable upper and applies each layer's stored
@@ -218,11 +245,21 @@ impl LayerManager {
             let merged = upper.join(reg);
             let base = base_dir.join(reg);
             if merged.exists() && base.exists() {
-                self.diff_one(&base, &merged, &patch_dir.join(format!("{reg}.patch")), hive)?;
+                self.diff_one(
+                    &base,
+                    &merged,
+                    &patch_dir.join(format!("{reg}.patch")),
+                    hive,
+                )?;
                 std::fs::remove_file(&merged)?;
             }
         }
-        self.run(&self.tools.fvs2, Some(upper), ["commit", "-m", message], "fvs2")
+        self.run(
+            &self.tools.fvs2,
+            Some(upper),
+            ["commit", "-m", message],
+            "fvs2",
+        )
     }
 
     /// Prepares a layered prefix and launches an application in it through
@@ -254,7 +291,10 @@ impl LayerManager {
             cmd.current_dir(d);
         }
         cmd.args(args);
-        let out = cmd.output().map_err(|e| LayersError::Spawn { tool: tool.into(), source: e })?;
+        let out = cmd.output().map_err(|e| LayersError::Spawn {
+            tool: tool.into(),
+            source: e,
+        })?;
         if !out.status.success() {
             return Err(LayersError::Tool {
                 tool: tool.into(),
@@ -295,7 +335,8 @@ fn is_mounted(target: &Path) -> bool {
         return false;
     };
     let target = target.to_string_lossy();
-    info.lines().any(|line| line.split(' ').nth(4) == Some(target.as_ref()))
+    info.lines()
+        .any(|line| line.split(' ').nth(4) == Some(target.as_ref()))
 }
 
 #[cfg(test)]
@@ -331,7 +372,9 @@ mod tests {
 
         let dep = work.join("dep");
         {
-            let mount = mgr.prepare(&[LayerRef::head(&virgo)], &dep, &work.join("mnt1")).unwrap();
+            let mount = mgr
+                .prepare(&[LayerRef::head(&virgo)], &dep, &work.join("mnt1"))
+                .unwrap();
             std::fs::write(mount.path().join("system32/newdep.dll"), b"newdep").unwrap();
             std::fs::write(mount.path().join("system.reg"), POST_REG).unwrap();
         }
@@ -339,16 +382,32 @@ mod tests {
         assert!(registry_patch_dir(&dep).join("system.reg.patch").exists());
 
         let mount = mgr
-            .prepare(&[LayerRef::head(&virgo), LayerRef::head(&dep)], &work.join("upper2"), &work.join("mnt2"))
+            .prepare(
+                &[LayerRef::head(&virgo), LayerRef::head(&dep)],
+                &work.join("upper2"),
+                &work.join("mnt2"),
+            )
             .unwrap();
         let merged = std::fs::read_to_string(mount.path().join("system.reg")).unwrap();
-        assert!(merged.contains("NewDep"), "merged registry should gain NewDep");
+        assert!(
+            merged.contains("NewDep"),
+            "merged registry should gain NewDep"
+        );
         assert!(merged.contains("\"Ver\"=\"2.0\""), "ToUpdate should be 2.0");
-        assert!(!merged.contains("ToDelete"), "ToDelete should be whiteed out");
-        assert_eq!(std::fs::read_to_string(mount.path().join("system32/newdep.dll")).unwrap(), "newdep");
+        assert!(
+            !merged.contains("ToDelete"),
+            "ToDelete should be whiteed out"
+        );
+        assert_eq!(
+            std::fs::read_to_string(mount.path().join("system32/newdep.dll")).unwrap(),
+            "newdep"
+        );
 
         let base = std::fs::read_to_string(virgo.join("system.reg")).unwrap();
-        assert!(base.contains("\"Ver\"=\"1.0\"") && base.contains("ToDelete"), "virgo must stay untouched");
+        assert!(
+            base.contains("\"Ver\"=\"1.0\"") && base.contains("ToDelete"),
+            "virgo must stay untouched"
+        );
 
         drop(mount);
         let _ = std::fs::remove_dir_all(&work);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,13 +4,19 @@ pub mod layers;
 pub mod runner;
 pub use error::Error;
 mod utils;
+pub mod virgo;
 mod winebridge;
 
 pub mod proto {
     tonic::include_proto!("winebridge");
     tonic::include_proto!("bottles");
+
+    pub mod fvs2d {
+        tonic::include_proto!("fvs2d.v1");
+    }
 }
 
+pub use crate::virgo::{Layer, LayerRevision, VirgoDaemon};
 pub use crate::winebridge::{
     DllOverride, DllOverrideMode, Drive, LaunchRequest, PathInfo, PathKind, Process, RegistryHive,
     RegistryKey, RegistryKeyValue, RegistryMultiString, RegistryValue, Service, ServiceStartType,

--- a/src/virgo.rs
+++ b/src/virgo.rs
@@ -1,0 +1,378 @@
+use std::net::{IpAddr, Ipv4Addr};
+use std::path::PathBuf;
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::time::Duration;
+
+use thiserror::Error;
+use tokio::sync::Mutex;
+use tonic::transport::{Channel, Endpoint};
+
+use crate::error::Result;
+use crate::proto::fvs2d::{self as pb, fvs2d_client};
+
+static VIRGO_ENDPOINT_MANAGER: LazyLock<VirgoEndpointManager> =
+    LazyLock::new(VirgoEndpointManager::new);
+
+#[derive(Error, Debug)]
+pub enum VirgoError {
+    #[error("The fvs2d process exited with status {0} before it reported readiness over gRPC.")]
+    DaemonExited(ExitStatus),
+    #[error("fvs2d did not report readiness before the startup timeout elapsed.")]
+    Timeout,
+}
+
+#[derive(Debug)]
+struct VirgoEndpointManager {
+    host: IpAddr,
+    next_port: AtomicU16,
+}
+
+impl VirgoEndpointManager {
+    fn new() -> Self {
+        Self {
+            host: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            next_port: AtomicU16::new(50151),
+        }
+    }
+
+    fn next(&self) -> Result<(Endpoint, IpAddr, u16)> {
+        let host = self.host;
+        let port = self.next_port.fetch_add(1, Ordering::Relaxed);
+        let endpoint = Endpoint::from_shared(format!("http://{host}:{port}"))?;
+        Ok((endpoint, host, port))
+    }
+}
+
+/// Revision selector for a mount layer.
+#[derive(Debug, Clone, Default)]
+pub enum LayerRevision {
+    /// The repository HEAD.
+    #[default]
+    Head,
+    /// A state id or unique prefix.
+    State(String),
+    /// A branch name.
+    Branch(String),
+}
+
+/// One lower layer of a mount, lowest to highest.
+#[derive(Debug, Clone)]
+pub struct Layer {
+    pub repository: PathBuf,
+    pub revision: LayerRevision,
+}
+
+impl Layer {
+    pub fn new(repository: impl Into<PathBuf>) -> Self {
+        Self {
+            repository: repository.into(),
+            revision: LayerRevision::Head,
+        }
+    }
+
+    pub fn state(mut self, state: impl Into<String>) -> Self {
+        self.revision = LayerRevision::State(state.into());
+        self
+    }
+
+    pub fn branch(mut self, branch: impl Into<String>) -> Self {
+        self.revision = LayerRevision::Branch(branch.into());
+        self
+    }
+
+    fn into_proto(self) -> pb::Layer {
+        let selector = match self.revision {
+            LayerRevision::Head => None,
+            LayerRevision::State(s) => Some(pb::revision_selector::Selector::StateIdOrPrefix(s)),
+            LayerRevision::Branch(b) => Some(pb::revision_selector::Selector::Branch(b)),
+        };
+        pb::Layer {
+            repository_path: self.repository.display().to_string(),
+            revision: selector.map(|selector| pb::RevisionSelector {
+                selector: Some(selector),
+            }),
+        }
+    }
+}
+
+/// Managed client for an fvs2d mount-manager daemon.
+///
+/// [`spawn`](Self::spawn) starts a dedicated daemon on a loopback endpoint and
+/// waits until it answers the `Probe` RPC; [`connect`](Self::connect) attaches
+/// to an already running daemon instead. A spawned daemon is stopped with
+/// [`shutdown`](Self::shutdown).
+pub struct VirgoDaemon {
+    client: Mutex<fvs2d_client::Fvs2dClient<Channel>>,
+    process: Option<Child>,
+}
+
+impl VirgoDaemon {
+    /// Starts an fvs2d manager on a fresh loopback endpoint and connects to it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the daemon cannot be spawned, exits before
+    /// readiness, or does not answer `Probe` within the startup timeout.
+    pub async fn spawn(executable: impl Into<PathBuf>) -> Result<Self> {
+        let (endpoint, host, port) = VIRGO_ENDPOINT_MANAGER.next()?;
+
+        let mut child = Command::new(executable.into())
+            .arg("-control")
+            .arg(format!("tcp:{host}:{port}"))
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()?;
+
+        let client = match Self::wait_until_ready(endpoint, &mut child, Duration::from_secs(15))
+            .await
+        {
+            Ok(client) => client,
+            Err(error) => {
+                if let Err(kill_error) = child.kill() {
+                    tracing::debug!(%kill_error, "Failed to kill fvs2d after startup failure");
+                }
+                if let Err(wait_error) = child.wait() {
+                    tracing::debug!(%wait_error, "Failed to wait for fvs2d after startup failure");
+                }
+                return Err(error);
+            }
+        };
+
+        Ok(Self {
+            client: Mutex::new(client),
+            process: Some(child),
+        })
+    }
+
+    /// Connects to an fvs2d manager that is already running at `addr`
+    /// (e.g. `http://127.0.0.1:50151`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the endpoint is invalid or the connection fails.
+    pub async fn connect(addr: impl Into<String>) -> Result<Self> {
+        let endpoint = Endpoint::from_shared(addr.into())?;
+        let client = fvs2d_client::Fvs2dClient::connect(endpoint).await?;
+        Ok(Self {
+            client: Mutex::new(client),
+            process: None,
+        })
+    }
+
+    async fn wait_until_ready(
+        endpoint: Endpoint,
+        process: &mut Child,
+        timeout: Duration,
+    ) -> Result<fvs2d_client::Fvs2dClient<Channel>> {
+        let ready = async {
+            loop {
+                if let Some(status) = process.try_wait()? {
+                    return Err(VirgoError::DaemonExited(status).into());
+                }
+
+                match fvs2d_client::Fvs2dClient::connect(endpoint.clone()).await {
+                    Ok(mut client) => match client.probe(()).await {
+                        Ok(_) => return Ok(client),
+                        Err(error) => {
+                            tracing::debug!(%error, "fvs2d probe failed");
+                        }
+                    },
+                    Err(error) => {
+                        tracing::debug!(%error, "fvs2d connection attempt failed");
+                    }
+                }
+
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        };
+
+        tokio::select! {
+            result = ready => result,
+            _ = tokio::time::sleep(timeout) => Err(VirgoError::Timeout.into()),
+        }
+    }
+
+    /// Returns daemon version and host capability flags.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the gRPC request fails.
+    pub async fn probe(&self) -> Result<pb::ProbeResponse> {
+        let mut client = self.client.lock().await;
+        Ok(client.probe(()).await?.into_inner())
+    }
+
+    /// Initializes (or opens) an FVS repository at `path`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the gRPC request fails or the daemon rejects it.
+    pub async fn init_repository(&self, path: impl Into<PathBuf>) -> Result<pb::Repository> {
+        let mut client = self.client.lock().await;
+        let response = client
+            .init_repository(pb::InitRepositoryRequest {
+                repository_path: path.into().display().to_string(),
+                block_size: 0,
+            })
+            .await?;
+        Ok(response.into_inner())
+    }
+
+    /// Creates a state (snapshot) of the repository at `path`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the gRPC request fails or the daemon rejects it.
+    pub async fn commit(
+        &self,
+        path: impl Into<PathBuf>,
+        message: impl Into<String>,
+    ) -> Result<pb::Revision> {
+        let mut client = self.client.lock().await;
+        let response = client
+            .commit(pb::CommitRequest {
+                repository_path: path.into().display().to_string(),
+                message: message.into(),
+                allow_empty: false,
+            })
+            .await?;
+        Ok(response.into_inner())
+    }
+
+    /// Lists the saved states of the repository at `path`, newest first.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the gRPC request fails.
+    pub async fn list_states(&self, path: impl Into<PathBuf>) -> Result<Vec<pb::State>> {
+        let mut client = self.client.lock().await;
+        let response = client
+            .list_states(pb::ListStatesRequest {
+                repository_path: path.into().display().to_string(),
+            })
+            .await?;
+        Ok(response.into_inner().states)
+    }
+
+    /// Restores a state into the repository working tree (exact checkout) and
+    /// moves HEAD to it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the gRPC request fails or the daemon rejects it.
+    pub async fn rollback(
+        &self,
+        path: impl Into<PathBuf>,
+        state: impl Into<String>,
+    ) -> Result<pb::RestoreResponse> {
+        let mut client = self.client.lock().await;
+        let response = client
+            .restore(pb::RestoreRequest {
+                repository_path: path.into().display().to_string(),
+                state_id_or_prefix: state.into(),
+                destination_path: None,
+                clean: true,
+                reset: true,
+            })
+            .await?;
+        Ok(response.into_inner())
+    }
+
+    /// Creates a restore point: initializes the repository if needed and
+    /// snapshots the current prefix content.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the gRPC request fails or the daemon rejects it.
+    pub async fn create_restore_point(
+        &self,
+        prefix: impl Into<PathBuf>,
+        label: impl Into<String>,
+    ) -> Result<pb::Revision> {
+        let prefix = prefix.into();
+        self.init_repository(prefix.clone()).await?;
+        self.commit(prefix, label).await
+    }
+
+    /// Mounts a stack of layers at `mount_point`, with an optional writable
+    /// upper directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the gRPC request fails or the daemon rejects it.
+    pub async fn create_mount(
+        &self,
+        mount_point: impl Into<PathBuf>,
+        layers: Vec<Layer>,
+        upper: Option<PathBuf>,
+    ) -> Result<pb::Mount> {
+        let mut client = self.client.lock().await;
+        let response = client
+            .create_mount(pb::CreateMountRequest {
+                spec: Some(pb::MountSpec {
+                    mount_point: mount_point.into().display().to_string(),
+                    layers: layers.into_iter().map(Layer::into_proto).collect(),
+                    upper_path: upper.map(|p| p.display().to_string()),
+                    debug: false,
+                }),
+            })
+            .await?;
+        Ok(response.into_inner())
+    }
+
+    /// Lists the mounts owned by the daemon.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the gRPC request fails.
+    pub async fn list_mounts(&self) -> Result<Vec<pb::Mount>> {
+        let mut client = self.client.lock().await;
+        Ok(client.list_mounts(()).await?.into_inner().mounts)
+    }
+
+    /// Unmounts a mount by id.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the gRPC request fails or the mount is unknown.
+    pub async fn unmount(&self, mount_id: impl Into<String>, lazy: bool) -> Result<()> {
+        let mode = if lazy {
+            pb::UnmountMode::Lazy
+        } else {
+            pb::UnmountMode::Normal
+        };
+        let mut client = self.client.lock().await;
+        client
+            .unmount(pb::UnmountRequest {
+                mount_id: mount_id.into(),
+                mode: mode as i32,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Asks the daemon to unmount everything and exit, then reaps the spawned
+    /// process if this client owns one.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the shutdown RPC fails.
+    pub async fn shutdown(mut self) -> Result<()> {
+        {
+            let mut client = self.client.lock().await;
+            client
+                .shutdown(pb::ShutdownRequest {
+                    mode: pb::UnmountMode::Normal as i32,
+                })
+                .await?;
+        }
+        if let Some(mut child) = self.process.take()
+            && let Err(wait_error) = child.wait()
+        {
+            tracing::debug!(%wait_error, "Failed to wait for fvs2d after shutdown");
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Adds the Virgo client for fvs2d: spawn or connect to the mount-manager daemon, create restore points, roll a prefix back, and mount layer stacks with a writable upper.

Verified end-to-end against a real fvs2d: snapshot -> break the prefix -> rollback restores it exactly; shared runtime layer mounted with a per-bottle upper.
