### PR TITLE
chore: follow fvs2d Commit type and ListCommits rename

### DIFF
--- a/proto/fvs2d.proto
+++ b/proto/fvs2d.proto
@@ -10,8 +10,8 @@ import "google/protobuf/timestamp.proto";
 service Fvs2d {
     rpc Probe(google.protobuf.Empty) returns (ProbeResponse);
     rpc InitRepository(InitRepositoryRequest) returns (Repository);
-    rpc Commit(CommitRequest) returns (Revision);
-    rpc ListStates(ListStatesRequest) returns (ListStatesResponse);
+    rpc Commit(CommitRequest) returns (.fvs2d.v1.Commit);
+    rpc ListCommits(ListCommitsRequest) returns (ListCommitsResponse);
     rpc Restore(RestoreRequest) returns (RestoreResponse);
     rpc CreateMount(CreateMountRequest) returns (Mount);
     rpc GetMount(GetMountRequest) returns (Mount);
@@ -20,18 +20,12 @@ service Fvs2d {
     rpc Shutdown(ShutdownRequest) returns (google.protobuf.Empty);
 }
 
-message ListStatesRequest {
+message ListCommitsRequest {
     string repository_path = 1;
 }
 
-message State {
-    string state_id = 1;
-    google.protobuf.Timestamp created_at = 2;
-    string message = 3;
-}
-
-message ListStatesResponse {
-    repeated State states = 1;
+message ListCommitsResponse {
+    repeated Commit commits = 1;
 }
 
 message RestoreRequest {
@@ -66,11 +60,12 @@ message CommitRequest {
     bool allow_empty = 3;
 }
 
-message Revision {
+message Commit {
     string repository_path = 1;
     string state_id = 2;
     google.protobuf.Timestamp created_at = 3;
     uint64 file_count = 4;
+    string message = 5;
 }
 
 message ProbeResponse {
@@ -84,7 +79,7 @@ message ProbeResponse {
     bool running_in_flatpak = 7;
 }
 
-message RevisionSelector {
+message CommitSelector {
     oneof selector {
         string state_id_or_prefix = 1;
         string branch = 2;
@@ -93,7 +88,7 @@ message RevisionSelector {
 
 message Layer {
     string repository_path = 1;
-    RevisionSelector revision = 2;
+    CommitSelector revision = 2;
 }
 
 message MountSpec {

--- a/src/virgo.rs
+++ b/src/virgo.rs
@@ -85,12 +85,12 @@ impl Layer {
     fn into_proto(self) -> pb::Layer {
         let selector = match self.revision {
             LayerRevision::Head => None,
-            LayerRevision::State(s) => Some(pb::revision_selector::Selector::StateIdOrPrefix(s)),
-            LayerRevision::Branch(b) => Some(pb::revision_selector::Selector::Branch(b)),
+            LayerRevision::State(s) => Some(pb::commit_selector::Selector::StateIdOrPrefix(s)),
+            LayerRevision::Branch(b) => Some(pb::commit_selector::Selector::Branch(b)),
         };
         pb::Layer {
             repository_path: self.repository.display().to_string(),
-            revision: selector.map(|selector| pb::RevisionSelector {
+            revision: selector.map(|selector| pb::CommitSelector {
                 selector: Some(selector),
             }),
         }
@@ -229,7 +229,7 @@ impl VirgoDaemon {
         &self,
         path: impl Into<PathBuf>,
         message: impl Into<String>,
-    ) -> Result<pb::Revision> {
+    ) -> Result<pb::Commit> {
         let mut client = self.client.lock().await;
         let response = client
             .commit(pb::CommitRequest {
@@ -246,14 +246,14 @@ impl VirgoDaemon {
     /// # Errors
     ///
     /// Returns an error if the gRPC request fails.
-    pub async fn list_states(&self, path: impl Into<PathBuf>) -> Result<Vec<pb::State>> {
+    pub async fn list_commits(&self, path: impl Into<PathBuf>) -> Result<Vec<pb::Commit>> {
         let mut client = self.client.lock().await;
         let response = client
-            .list_states(pb::ListStatesRequest {
+            .list_commits(pb::ListCommitsRequest {
                 repository_path: path.into().display().to_string(),
             })
             .await?;
-        Ok(response.into_inner().states)
+        Ok(response.into_inner().commits)
     }
 
     /// Restores a state into the repository working tree (exact checkout) and
@@ -290,7 +290,7 @@ impl VirgoDaemon {
         &self,
         prefix: impl Into<PathBuf>,
         label: impl Into<String>,
-    ) -> Result<pb::Revision> {
+    ) -> Result<pb::Commit> {
         let prefix = prefix.into();
         self.init_repository(prefix.clone()).await?;
         self.commit(prefix, label).await


### PR DESCRIPTION
Keeps the Virgo client in sync with fvs2d v0.10.0: unified `Commit` message, `ListCommits`, `CommitSelector`.